### PR TITLE
Fix Composer autoload path and service provider namespace

### DIFF
--- a/ServiceProvider.php
+++ b/ServiceProvider.php
@@ -6,7 +6,7 @@ use League\Container\ServiceProvider\AbstractServiceProvider;
 use Psr\Log\LoggerInterface;
 use Maxyc\TelegramBot\Bot\TelegramBot;
 use Maxyc\TelegramBot\Bot\MessageHandler;
-use Maxyc\TelegramBot\Bot\TelegramClient;
+use Maxyc\TelegramBot\Client\TelegramClient;
 use Maxyc\TelegramBot\Client\AkismetClient;
 use Maxyc\TelegramBot\Client\GigaChatClient;
 use Maxyc\TelegramBot\Checks\SpamStrategyFactory;

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Maxyc\\TelegramBot\\": "src/"
+            "Maxyc\\TelegramBot\\": ""
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
## Summary
- fix PSR-4 autoload path so classes load from project root
- correct TelegramClient namespace in ServiceProvider

## Testing
- `composer dump-autoload` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419e857b58832fbb02955a7b9e7d92